### PR TITLE
ci: migrate CodeQL runner to self-hosted ARC (master)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Migrate the CodeQL analyze job from GitHub-hosted `ubuntu-latest` to `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (smallest _4 per CodeQL policy). k8s-build.yml already uses RUNNER_LINUX_X64_4 and is untouched.